### PR TITLE
show accurate times

### DIFF
--- a/lib/client/bench.go
+++ b/lib/client/bench.go
@@ -94,7 +94,7 @@ func (tc *TeleportClient) Benchmark(ctx context.Context, bench Benchmark) (*Benc
 				// this is to account for coordinated omission,
 				// http://psy-lob-saw.blogspot.com/2015/03/fixing-ycsb-coordinated-omission.html
 				measure := &benchMeasure{
-					Start: time.Now(),
+					ResponseStart: time.Now(),
 				}
 				select {
 				case requestC <- measure:
@@ -139,7 +139,7 @@ func (tc *TeleportClient) Benchmark(ctx context.Context, bench Benchmark) (*Benc
 					result.LastError = measure.Error
 				}
 				result.RequestsOriginated++
-				result.Histogram.RecordValue(int64(measure.End.Sub(measure.Start) / time.Millisecond))
+				result.Histogram.RecordValue(int64(measure.End.Sub(measure.ResponseStart) / time.Millisecond))
 			}
 		}
 	}
@@ -147,7 +147,8 @@ func (tc *TeleportClient) Benchmark(ctx context.Context, bench Benchmark) (*Benc
 }
 
 type benchMeasure struct {
-	Start           time.Time
+	ResponseStart   time.Time
+	ServiceStart    time.Time
 	End             time.Time
 	ThreadCompleted bool
 	ThreadID        int
@@ -165,6 +166,7 @@ type benchmarkThread struct {
 }
 
 func (b *benchmarkThread) execute(measure *benchMeasure) {
+	measure.ServiceStart = time.Now()
 	if !b.interactive {
 		// do not use parent context that will cancel in flight requests
 		// because we give test some time to gracefully wrap up


### PR DESCRIPTION
Corrected coordinated omission. The ascii table now shows accurate times of the benchmark.
## Implementation
Added another field to bench measure which has the scheduled start time (the start of the response) and then the observed time (service time).

`tsh bench --export --duration 10s --rate 100 localhost ls -l /`

As you can see below, the last sent request was ~600, so ~6 seconds into the 10s duration. And the 100th percentile duration is ~4000s which shows it is taking response time into account, not just service time. 

```
* Requests originated: 611
* Requests failed: 7
* Last error: several requests hang: timeout waiting for 5 threads to finish

Histogram

Percentile Duration 
---------- -------- 
25         24 ms    
50         27 ms    
75         33 ms    
90         63 ms    
95         90 ms    
99         3411 ms  
100        4431 ms 
``` 
